### PR TITLE
Fix some bugs

### DIFF
--- a/BinaryDecompiler/include/hlslcc.h
+++ b/BinaryDecompiler/include/hlslcc.h
@@ -1,6 +1,7 @@
 #ifndef HLSLCC_H_
 #define HLSLCC_H_
 
+#include <string>
 #include <vector>
 #include <map>
 

--- a/D3D_Shaders/Assembler.cpp
+++ b/D3D_Shaders/Assembler.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include <stdexcept>
 
 using namespace std;
 

--- a/HLSLDecompiler/DecompileHLSL.cpp
+++ b/HLSLDecompiler/DecompileHLSL.cpp
@@ -3042,6 +3042,9 @@ public:
 			else if (!strcmp(statement, "dcl_constantbuffer"))
 			{
 				char *strPos = strstr(op1, "cb");
+				if (!strPos) // sometimes the disassembler puts uppercase
+					strPos = strstr(op1, "CB");
+
 				if (strPos)
 				{
 					int bufIndex = 0;
@@ -3068,7 +3071,8 @@ public:
 					// and create the fake cb2 style names as the best we can do.  
 					// Not sure this will work in all cases, because the offsets into the buffer are
 					// not required to be zero for the first element, but we have no other info here.
-					if (mCBufferNames.empty())
+					// There will still always be a single cbuffer in here, since it is made in ParseBufferDefinitions.
+					if (mCBufferNames.size() <= 1)
 					{
 						BufferEntry e;
 						e.bt = DT_float4;


### PR DESCRIPTION
Hey. This looks pretty abandoned, but in case it isn't, I made a few fixes.

- When building on newer versions of VS using Windows 10, I ran into to issues that required including a few more headers.

- The DXBC binaries I was looking at would sometimes use uppercase `CB` when declaring constant buffers. I made the code that parses these case insensitive.

- `mCBufferNames` is never empty since an entry is added explicitly in `ParseBufferDefinitions`. I changed a check that relies on it being empty to account for this. This lets the binaries I was reversing successfully decompile, since the explicit cbuffer info in comments isn't present for them.

I'm guessing this won't be merged, but I hope this might help people trying to use this in the future.